### PR TITLE
Add macOS ARM64 (Apple Silicon) support

### DIFF
--- a/pd.cmake
+++ b/pd.cmake
@@ -194,7 +194,7 @@ macro(pd_set_lib_ext OBJ_TARGET_NAME)
     endif()
 
     if(APPLE)
-        if(HAVE_ARM64)
+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
             set(PD_EXTENSION ".darwin-arm64-${PD_FLOATSIZE}.so")
         else()
             set(PD_EXTENSION ".darwin-amd64-${PD_FLOATSIZE}.so")


### PR DESCRIPTION
## Summary
Hi! This PR adds support for macOS ARM64 (Apple Silicon) by improving architecture detection in **pd.cmake**.

## Changes
- Improved architecture detection for macOS:
  - Replaced the custom `HAVE_ARM64` variable with CMake’s built-in `CMAKE_SYSTEM_PROCESSOR`
  - Correctly generates `.darwin-arm64-*.so` filenames on Apple Silicon Macs

## Testing
- ✅ Successfully builds on macOS ARM64
- ✅ Generates the correct binary filename (`.darwin-arm64-32.so`)

The previous implementation relied on `HAVE_ARM64`, which was not properly set on macOS.  
Using CMake’s standard `CMAKE_SYSTEM_PROCESSOR` variable ensures consistent and reliable architecture detection across platforms.
